### PR TITLE
Fix regression in encoding of properties and provide affordances for stable ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,7 @@ This library focuses solely on defining and serializing JSON Schema values
 with a clean, ergonomic API. <br/>
 _That's it_.
 
-The [implementation](/Sources/JSONSchema/) is deliberately minimal:
-two files, ~1,000 lines of code total.
+The [implementation](/Sources/JSONSchema/) is deliberately minimal.
 At its core is one big `JSONSchema` enumeration
 with associated values for most of the JSON Schema keywords you might want.
 No result builders, property wrappers, macros, or dynamic member lookup —


### PR DESCRIPTION
Resolves #11 

The changes in #9 attempted to provide a stable ordering of JSON Schema properties using [`OrderedDictionary` from `apple/swift-collections`](https://github.com/apple/swift-collections?tab=readme-ov-file). However, that type encodes as a JSON array instead of a JSON object, resulting in invalid JSON Schema documents.

This PR resolves this regression and adds new affordances in support of preserving order:

- A static `extractSchemaPropertyOrder` method that extracts property order from the top-level `"properties"` field of a JSON Schema object.
- A static `extractPropertyOrder` method that extracts property order from any JSON object at a specified keypath.
- A static `propertyOrderUserInfoKey` constant that you can pass to `JSONDecoder` (determined with either extraction method or some other means) to guide the ordering of JSON Schema object properties.

## Example Usage

```swift
let json = """
{
  "type": "object",
  "properties": {
    "firstName": {"type": "string"},
    "lastName": {"type": "string"},
    "age": {"type": "integer"},
    "email": {"type": "string", "format": "email"}
  }
}
""".data(using: .utf8)!

// Extract property order from a JSON Schema object's "properties" field
if let propertyOrder = JSONSchema.extractSchemaPropertyOrder(from: jsonData) {
    // Configure decoder to preserve order
    let decoder = JSONDecoder()
    decoder.userInfo[JSONSchema.propertyOrderUserInfoKey] = propertyOrder

    // Decode with preserved property order
    let schema = try decoder.decode(JSONSchema.self, from: data)

    // Properties will maintain their original order: `firstName`, `lastName`, `age`, `email`
}

// Or extract from a nested object using a keypath
let nestedJSONData = """
{
  "definitions": {
    "person": {
      "firstName": "John",
      "lastName": "Doe"
    }
  }
}
""".data(using: .utf8)!

let keyOrder = JSONSchema.extractPropertyOrder(from: nestedJSONData, 
                                               at: ["definitions", "person"]) 
// keyOrder will be ["firstName", "lastName"]
```
