### PR TITLE
Use FoundationEssentials when available

### DIFF
--- a/Sources/JSONSchema/JSONSchema.swift
+++ b/Sources/JSONSchema/JSONSchema.swift
@@ -1,4 +1,8 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import OrderedCollections
 
 #if canImport(RegexBuilder)

--- a/Sources/JSONSchema/JSONValue.swift
+++ b/Sources/JSONSchema/JSONValue.swift
@@ -1,6 +1,12 @@
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.Data
+import class FoundationEssentials.JSONDecoder
+import class FoundationEssentials.JSONEncoder
+#else
 import struct Foundation.Data
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
+#endif
 
 /// A representation of a JSON value.
 ///

--- a/Tests/JSONSchemaTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaTests/JSONSchemaTests.swift
@@ -1,4 +1,8 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Testing
 
 @testable import JSONSchema

--- a/Tests/JSONSchemaTests/JSONValueTests.swift
+++ b/Tests/JSONSchemaTests/JSONValueTests.swift
@@ -1,4 +1,8 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Testing
 
 @testable import JSONSchema


### PR DESCRIPTION
As per [The adoption of `import FoundationEssentials` throughout the package ecosystem](https://forums.swift.org/t/the-adoption-of-import-foundationessentials-throughout-the-package-ecosystem/84112), this PR prefers to import `FoundationEssentials` when available which helps with binary sizes in non-Darwin platforms.